### PR TITLE
feat: send without secret recovery phrase

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,25 +1,5 @@
-import { getPrivateMessagingKey, privateMessagingKeyFromHex } from "@mailchain/sdk/internal";
-import { KeyRing } from "@mailchain/keyring";
-import { MailSender } from "@mailchain/sdk/internal";
-import { ED25519PrivateKey } from "@mailchain/crypto";
-import { decodeHex } from "@mailchain/encoding";
-import { encodeHex } from "@mailchain/encoding";
+import { MailSender, privateMessagingKeyFromHex } from "@mailchain/sdk/internal";
 import "dotenv/config";
-
-const createPrivateMessagingKey = async () => {
-  const keyRing = KeyRing.fromSecretRecoveryPhrase(
-    process.env.SECRET_KEY_RECOVERY_PHRASE as string
-  );
-
-  const mailchainAddress = process.env.MAILCHAIN_ADDRESS as string;
-
-  const { data: privateMessagingKey, error: getPrivateMessagingKeyError } =
-    await getPrivateMessagingKey(mailchainAddress, keyRing);
-
-  if (getPrivateMessagingKeyError) throw getPrivateMessagingKeyError;
-
-  return encodeHex(privateMessagingKey.publicKey.bytes);
-};
 
 const createMailSender = () => {
   const privateMessagingKey = privateMessagingKeyFromHex(process.env.ADDRESS_PRIVATE_MESSAGING_KEY as string);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@mailchain/encoding": "^0.18.2",
-        "@mailchain/keyring": "^0.18.2",
-        "@mailchain/sdk": "^0.18.2",
+        "@mailchain/sdk": "^0.18.4",
         "dotenv": "^16.0.3",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.3"
@@ -297,9 +295,9 @@
       }
     },
     "node_modules/@ethersproject/signing-key": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
-      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
+      "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
       "funding": [
         {
           "type": "individual",
@@ -311,9 +309,9 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/bytes": "^5.6.1",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
         "bn.js": "^5.2.1",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
@@ -365,6 +363,29 @@
         "@ethersproject/signing-key": "^5.7.0"
       }
     },
+    "node_modules/@ethersproject/transactions/node_modules/@ethersproject/signing-key": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "bn.js": "^5.2.1",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.7"
+      }
+    },
     "node_modules/@ethersproject/web": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
@@ -410,32 +431,32 @@
       }
     },
     "node_modules/@mailchain/addressing": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@mailchain/addressing/-/addressing-0.18.2.tgz",
-      "integrity": "sha512-NO4oVgMrJGF7+GKJISWiD2c08CC1cqiNvifw9XMIjyRrZUihUfJ1Z6C2EbnfL4PGJXG6Xd6rg/4H07HutoMF6g==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@mailchain/addressing/-/addressing-0.18.4.tgz",
+      "integrity": "sha512-46NSxdFY9AvSQvOGJi4/GSYZv8pVWN9VQ6wMzbRPfxk020+CNBj7EI+HSa3SWcvF+0LhVQulMp30mIJDvdk2Qw==",
       "dependencies": {
         "@ethersproject/transactions": "^5.7.0",
-        "@mailchain/crypto": "0.18.2",
-        "@mailchain/encoding": "0.18.2",
+        "@mailchain/crypto": "0.18.4",
+        "@mailchain/encoding": "0.18.4",
         "@noble/hashes": "^1.3.0",
         "@polkadot/util-crypto": "10.1.11"
       }
     },
     "node_modules/@mailchain/api": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@mailchain/api/-/api-0.18.2.tgz",
-      "integrity": "sha512-JCgmyI4ysP+TrTia9IuIm0Wb0gfRuJb7ggUYt8CS0/iazhtej7o/GJ2uMVA6qkCLJrnJnzZ5v476wXwKBbzEbA==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@mailchain/api/-/api-0.18.4.tgz",
+      "integrity": "sha512-fLKskh3VKCLZIrpO5k42O/xBV35/2JOuFOkdoxIni5oNI7k+yStiq/rL21e3BEVPz7A75DNve8cSDwLo2BD/BQ==",
       "dependencies": {
-        "@mailchain/crypto": "0.18.2",
-        "@mailchain/encoding": "0.18.2",
+        "@mailchain/crypto": "0.18.4",
+        "@mailchain/encoding": "0.18.4",
         "axios": "1.3.4",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@mailchain/crypto": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@mailchain/crypto/-/crypto-0.18.2.tgz",
-      "integrity": "sha512-jOd26GJ36ptMqXGLno7xqzhwWV6gbKmhfh4Ka/t+nsvyX0I6kGFXHJlJwMoEzuZlNMNgJbObzdMfncyyFNENGg==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@mailchain/crypto/-/crypto-0.18.4.tgz",
+      "integrity": "sha512-Saq8ATXjLxliLqTiJhwMve3akaTBjk70TBniKFRiWFBlALeDRo/EDsmRk2FzvNqgmtNAEm93yMgOKfzoHug/ng==",
       "dependencies": {
         "@ethersproject/hash": "5.7.0",
         "@ethersproject/signing-key": "5.6.2",
@@ -452,50 +473,27 @@
         "node": ">=15.0.0"
       }
     },
-    "node_modules/@mailchain/crypto/node_modules/@ethersproject/signing-key": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
-      "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "bn.js": "^5.2.1",
-        "elliptic": "6.5.4",
-        "hash.js": "1.1.7"
-      }
-    },
     "node_modules/@mailchain/encoding": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@mailchain/encoding/-/encoding-0.18.2.tgz",
-      "integrity": "sha512-aXb5iRiJBteY2jd7F3eKqcHzS9fA8YnC+ig8b0K1ZoON8D0ao0+Sid3iAkkkQ8ObKMIJJTKR6H3UbXWPKrR9Hw==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@mailchain/encoding/-/encoding-0.18.4.tgz",
+      "integrity": "sha512-30U90iIGeomu2sCZt3wvIh+Uyu8gCjKdY/a1ELAd3XYE4m0+4UpFI1LCcuwk/1cDKa/weLVMJHpelmtmZz9wrA==",
       "dependencies": {
         "@noble/hashes": "^1.3.0",
         "@polkadot/util-crypto": "10.1.11"
       }
     },
     "node_modules/@mailchain/internal": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@mailchain/internal/-/internal-0.18.2.tgz",
-      "integrity": "sha512-AAPak4EusJpQmiu0MWWqPrhe1vgNP2rR6go6P/IGaV1VbJzfMKAHgdbsTJOjEHmwSXbFzPyXy65J9VwOBtmXxw==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@mailchain/internal/-/internal-0.18.4.tgz",
+      "integrity": "sha512-+lzbLAcns/H3LGyqAfT5lgaFezo86PEOp/MDH2oWiWFYpLEVGIrZ3lM3B4mtA742bFEoiPTrzJjIkQCckZcYNA==",
       "dependencies": {
-        "@mailchain/addressing": "0.18.2",
-        "@mailchain/api": "0.18.2",
-        "@mailchain/crypto": "0.18.2",
-        "@mailchain/encoding": "0.18.2",
-        "@mailchain/keyring": "0.18.2",
-        "@mailchain/message-composer": "0.18.2",
-        "@mailchain/signatures": "0.18.2",
+        "@mailchain/addressing": "0.18.4",
+        "@mailchain/api": "0.18.4",
+        "@mailchain/crypto": "0.18.4",
+        "@mailchain/encoding": "0.18.4",
+        "@mailchain/keyring": "0.18.4",
+        "@mailchain/message-composer": "0.18.4",
+        "@mailchain/signatures": "0.18.4",
         "@noble/hashes": "^1.3.0",
         "axios": "1.3.4",
         "canonicalize": "^1.0.8",
@@ -506,47 +504,47 @@
       }
     },
     "node_modules/@mailchain/keyring": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@mailchain/keyring/-/keyring-0.18.2.tgz",
-      "integrity": "sha512-wntaMPfHZaJRR3nMZxEjROwGX2AY6zoLgq5oGwsxS1hI2d3t05HrZJHtOkHAU74GXO93uEofsF/rdCtGX6bA8w==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@mailchain/keyring/-/keyring-0.18.4.tgz",
+      "integrity": "sha512-eLOEgBDrug8fZF86eRaU/NyP6MYFo7QqFtCApyqnmZUXRWGMUct2kGj5y/1iTfWUQUnw4khEUzvtXlv9mOi9DQ==",
       "dependencies": {
-        "@mailchain/addressing": "0.18.2",
-        "@mailchain/crypto": "0.18.2",
-        "@mailchain/encoding": "0.18.2"
+        "@mailchain/addressing": "0.18.4",
+        "@mailchain/crypto": "0.18.4",
+        "@mailchain/encoding": "0.18.4"
       }
     },
     "node_modules/@mailchain/message-composer": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@mailchain/message-composer/-/message-composer-0.18.2.tgz",
-      "integrity": "sha512-mc5M8r3Gr5BXvkWYRNAlPpJtxwCuR0qshrDieBPZ8rNBAv2tvwohJnqi0DtDC8TnDT079JVP5TIwhgnzEj2+IA==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@mailchain/message-composer/-/message-composer-0.18.4.tgz",
+      "integrity": "sha512-IGtJoAZ84T4lJnWnNVyRyjdHxjc2lWXdkcGwTXrE5og6dXAHYP6WIFOR3wtX5O+c7B5Vr2eiI4fh5j5iShc8yw==",
       "dependencies": {
-        "@mailchain/encoding": "0.18.2",
+        "@mailchain/encoding": "0.18.4",
         "date-fns": "^2.29.2"
       }
     },
     "node_modules/@mailchain/sdk": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@mailchain/sdk/-/sdk-0.18.2.tgz",
-      "integrity": "sha512-U79b97OrHwVHm98r1JxNOxaiJAB7ZayXlJloi8Qu13ew2qqyE97GFNIo3LaqH5NCsLl8kpYZJNn+ElOK9Dp9Tw==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@mailchain/sdk/-/sdk-0.18.4.tgz",
+      "integrity": "sha512-myPH9eMidRxDv1WRB8Awy7daLUIv+7PSNkO+StS5knv4qJtD4SnyMn1rGTVVgTrc30roheTjT7RgWEjqmC5qSQ==",
       "dependencies": {
-        "@mailchain/crypto": "0.18.2",
-        "@mailchain/encoding": "0.18.2",
-        "@mailchain/internal": "0.18.2",
-        "@mailchain/keyring": "0.18.2"
+        "@mailchain/crypto": "0.18.4",
+        "@mailchain/encoding": "0.18.4",
+        "@mailchain/internal": "0.18.4",
+        "@mailchain/keyring": "0.18.4"
       },
       "engines": {
         "node": ">=15.0.0"
       }
     },
     "node_modules/@mailchain/signatures": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@mailchain/signatures/-/signatures-0.18.2.tgz",
-      "integrity": "sha512-U1zSdXqUv9orfsCrsfkHYd5zH7D0oTn2fU/VxJw1ZSJsreCcuMPhDHMMM/ls4GyEtZ+7WtT8sxkdNcY6cHC2sQ==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@mailchain/signatures/-/signatures-0.18.4.tgz",
+      "integrity": "sha512-2P+X+TtU7cXh7giAT02ATnHKtYULFJ8h7Qrh5AkBf3dZ0rRyZlCYkZGcgqUbAEVgFluOWklmKyn/8g/QG5dkxw==",
       "dependencies": {
         "@ethersproject/hash": "5.7.0",
-        "@mailchain/addressing": "0.18.2",
-        "@mailchain/crypto": "0.18.2",
-        "@mailchain/encoding": "0.18.2",
+        "@mailchain/addressing": "0.18.4",
+        "@mailchain/crypto": "0.18.4",
+        "@mailchain/encoding": "0.18.4",
         "@polkadot/util-crypto": "10.1.11",
         "canonicalize": "^1.0.8",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@mailchain/encoding": "^0.18.2",
-    "@mailchain/keyring": "^0.18.2",
-    "@mailchain/sdk": "^0.18.2",
+    "@mailchain/sdk": "^0.18.4",
     "dotenv": "^16.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.3"


### PR DESCRIPTION
The PR shows how to send mails using Mailchain without the need for the Secret Recovery Phrase. Instead this using a `Messaging Key` for the address you want to send from. Note a `Messaging Key` is not a wallet key, therefore it cannot transact or perform wallet signing. 

I tried to follow your structure to demo getting a `MailSender` authenticated and ready for sending.

You can now get your `Messaging Key` from the web interface by navigating to https://app.mailchain.com/settings/accounts/ and clicking on `View messaging key` for the corresponding address.

<img width="1055" alt="image" src="https://user-images.githubusercontent.com/1633235/230380732-30a7ebeb-60ab-45e9-a6f8-2a86f1b0cb31.png">

You will need to authenticate to reveal your `Private Messaging Key`
<img width="949" alt="image" src="https://user-images.githubusercontent.com/1633235/230380553-d25df3a1-9b9d-4014-9526-0d8856566611.png">

Changes:
- Update to `v0.18.4` - means you don't need to import or install any other packages.
- Use `privateMessagingKeyFromHex` to load your key that you can get from the UI. See https://docs.mailchain.com/developer/advanced/private-messaging-key/ for more information how this works.